### PR TITLE
feat: add functionality to end election

### DIFF
--- a/Foundry_Contracts/src/Voting.sol
+++ b/Foundry_Contracts/src/Voting.sol
@@ -53,7 +53,7 @@ function authorize(address _person) public ownerOnly {
     voters[_person].authorized = true;
 }
 
-function vote(uint _voteIndex) public {
+function vote(uint _voteIndex) public electionOngoing(){
   require(!voters[msg.sender].voted, Voting__AlreadyVoted());
   require(voters[msg.sender].authorized, Voting__NotAuthorized());
   require(_voteIndex<candidates.length, Voting__IncorrectVoteIndex());

--- a/Foundry_Contracts/src/Voting.sol
+++ b/Foundry_Contracts/src/Voting.sol
@@ -17,6 +17,7 @@ struct Candidate{
 
 address public owner;
 string public electionName;
+bool public electionEnded = false;
 
 mapping(address => Voter) public voters;
 Candidate[] public candidates;
@@ -39,6 +40,11 @@ modifier ownerOnly(){
  _;
 }
 
+modifier electionOngoing() {
+    require(!electionEnded, "Election has ended");
+    _;
+}
+
 function addCandidate(string memory _name) public ownerOnly{
   candidates.push(Candidate(candidates.length, _name, 0));
 }
@@ -56,6 +62,10 @@ function vote(uint _voteIndex) public {
   candidates[_voteIndex].voteCount += 1;
   totalVotes +=1;
 }
+
+function endElection() public ownerOnly { 
+        electionEnded = true;
+    }
 
 function getCandidates() public view returns (Candidate[] memory) {
   return candidates;


### PR DESCRIPTION
issue #24 

- Introduced `electionEnded` flag to track the election status.
- Implemented `electionOngoing` modifier to restrict access to voting while the election is ongoing.
- Added `endElection()` function for the owner to end the election, preventing further voting.
- Updated the `vote()` function to use the new modifier for election status checks.